### PR TITLE
Update site_config.yml

### DIFF
--- a/_data/site_config.yml
+++ b/_data/site_config.yml
@@ -203,9 +203,10 @@ metadata_tabs:
   - scope: global
     title: indicator.global_metadata
     description: indicator.global_metadata_blurb
-  - scope: sources
-    title: indicator.sources
-    description: ''
+  - scope: sources_alt
+    title: Sources
+    description: Data sources for this development goal.
+    placeholder: No sources are available at this time
 meta_tags: []
 news:
   category_links: false


### PR DESCRIPTION
updating site_config's metadata_tabs to replace original sources set up that was deprecated with the new update. 

https://open-sdg.readthedocs.io/en/latest/configuration/#metadata_tabs:~:text=sources%3A%20This%20deprecated%20scope%20takes%20its%20content%20from%20the%20source_*_1%2C%20source_*_2%2C%20etc%2C%20metadata%20fields.%20This%20scope%20is%20deprecated%20and%20sources_alt%20(see%20below)%20is%20recommended%20instead.